### PR TITLE
feat: Use Host prefix only in production mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+MODE=development
+
 DATABASE_URL=mysql://root:password@127.0.0.1:3306/nugu
 
 AUTH_GOOGLE_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-MODE=development
+NODE_ENV=development
 
 DATABASE_URL=mysql://root:password@127.0.0.1:3306/nugu
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 export const env = z
   .object({
+    MODE: z.enum(['development', 'production']),
     DATABASE_URL: z.string().url(),
     AUTH_GOOGLE_CLIENT_ID: z.string().nonempty(),
     AUTH_GOOGLE_CLIENT_SECRET: z.string().nonempty(),

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const env = z
   .object({
-    MODE: z.enum(['development', 'production']),
+    NODE_ENV: z.enum(['development', 'testing', 'staging', 'production']),
     DATABASE_URL: z.string().url(),
     AUTH_GOOGLE_CLIENT_ID: z.string().nonempty(),
     AUTH_GOOGLE_CLIENT_SECRET: z.string().nonempty(),

--- a/src/lib/cookie.ts
+++ b/src/lib/cookie.ts
@@ -18,7 +18,7 @@ const cookieOptions = {
   httpOnly: true,
   secure: true,
   sameSite: 'none',
-  prefix: env.MODE === 'production' ? 'host' : undefined,
+  prefix: env.NODE_ENV === 'production' ? 'host' : undefined,
 } as const satisfies CookieOptions
 type SetCookieOptions = Omit<CookieOptions, keyof typeof cookieOptions>
 

--- a/src/lib/cookie.ts
+++ b/src/lib/cookie.ts
@@ -14,19 +14,21 @@ const cookieSchema = z.object({
 type Cookie = z.infer<typeof cookieSchema>
 type CookieKey = keyof Cookie
 
-const defaultSetOptions = {
+const cookieOptions = {
   httpOnly: true,
   secure: true,
   sameSite: 'none',
-  prefix: 'host',
+  prefix: env.MODE === 'production' ? 'host' : undefined,
 } as const satisfies CookieOptions
-type SetCookieOptions = Omit<CookieOptions, keyof typeof defaultSetOptions>
+type SetCookieOptions = Omit<CookieOptions, keyof typeof cookieOptions>
 
 const getCookie = async <TKey extends CookieKey>(
   c: Context,
   key: TKey,
 ): Promise<{ ok: true; data: Cookie[TKey] | undefined } | { ok: false }> => {
-  const value = await getSignedCookie(c, env.COOKIE_SECRET, key, 'host')
+  const value = await (cookieOptions.prefix === undefined
+    ? getSignedCookie(c, env.COOKIE_SECRET, key)
+    : getSignedCookie(c, env.COOKIE_SECRET, key, cookieOptions.prefix))
 
   if (value === false) return { ok: false }
   if (value === undefined) return { ok: true, data: undefined }
@@ -40,12 +42,12 @@ const setCookie = <TKey extends CookieKey>(
   options?: SetCookieOptions,
 ) =>
   setSignedCookie(c, key, JSON.stringify(value), env.COOKIE_SECRET, {
-    ...defaultSetOptions,
+    ...cookieOptions,
     ...options,
   })
 
 const deleteCookie = <TKey extends CookieKey>(c: Context, key: TKey) => {
-  _deleteCookie(c, key, { prefix: 'host' })
+  _deleteCookie(c, key, { prefix: cookieOptions.prefix })
 }
 
 export const cookie = {


### PR DESCRIPTION
### 내용

- `NODE_ENV` 환경변수를 추가합니다.
- `NODE_ENV === 'production'`인 경우에만 `__Host-` prefix를 사용합니다.
- 위 설정으로 로컬 환경에서 개발 시 쿠키가 설정되지 않는 문제를 해결합니다.