### PR TITLE
feat: Support user sign-out

### DIFF
--- a/src/modules/auth/authGuard.ts
+++ b/src/modules/auth/authGuard.ts
@@ -29,5 +29,10 @@ export const signAuthToken = (payload: AuthTokenPayload) => {
   return jwt.sign<'authToken'>({ iat, ...payload })
 }
 
-export const setAuthToken = (c: Context, token: string) =>
-  cookie.set(c, 'authToken', token, { maxAge: 3600 })
+export const setAuthToken = async (c: Context, token: string) => {
+  await cookie.set(c, 'authToken', token, { maxAge: 3600 })
+}
+
+export const removeAuthToken = (c: Context) => {
+  cookie.delete(c, 'authToken')
+}

--- a/src/modules/auth/authRoute.ts
+++ b/src/modules/auth/authRoute.ts
@@ -4,7 +4,11 @@ import { HTTPException } from 'hono/http-exception'
 import { v4 as uuidv4 } from 'uuid'
 import { z } from 'zod'
 import { env } from '@/env'
-import { setAuthToken, signAuthToken } from '@/modules/auth/authGuard'
+import {
+  removeAuthToken,
+  setAuthToken,
+  signAuthToken,
+} from '@/modules/auth/authGuard'
 import * as authService from '@/modules/auth/authService'
 import { google } from '@/modules/auth/google'
 
@@ -15,6 +19,10 @@ import { google } from '@/modules/auth/google'
 const states = new Map<string, string>()
 
 const app = new Hono()
+  .get('/signout', (c) => {
+    removeAuthToken(c)
+    return c.redirect(env.DEFAULT_REDIRECT_URL)
+  })
   .get('/google', (c) => {
     const from = c.req.query('from')
     const state = uuidv4()


### PR DESCRIPTION
### 내용

- `/auth/signout` 엔드포인트를 추가합니다.
- 로그아웃 시 쿠키의 auth token을 제거하고 `/`로 리다이렉트합니다.