### PR TITLE
feat: Implement RBAC

### DIFF
--- a/src/db/migration/0002_smooth_monster_badoon.sql
+++ b/src/db/migration/0002_smooth_monster_badoon.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `user_role` (
+	`user_id` int NOT NULL,
+	`role` varchar(20) NOT NULL,
+	`created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT `user_role_user_id_role_pk` PRIMARY KEY(`user_id`,`role`)
+);
+--> statement-breakpoint
+ALTER TABLE `user_role` ADD CONSTRAINT `user_role_user_id_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `idx_user_role_01` ON `user_role` (`user_id`);

--- a/src/db/migration/meta/0002_snapshot.json
+++ b/src/db/migration/meta/0002_snapshot.json
@@ -1,0 +1,307 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "03a6d06f-6d07-4dfa-badd-b8d70c2d7580",
+  "prevId": "6bab1967-ac91-4f47-aaf5-223b49f590d7",
+  "tables": {
+    "auth_account": {
+      "name": "auth_account",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_auth_account_01": {
+          "name": "idx_auth_account_01",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_user_id_fk": {
+          "name": "auth_account_user_id_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_account_provider_provider_account_id_pk": {
+          "name": "auth_account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user_role": {
+      "name": "user_role",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_user_role_01": {
+          "name": "idx_user_role_01",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_role_user_id_user_id_fk": {
+          "name": "user_role_user_id_user_id_fk",
+          "tableFrom": "user_role",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_role_user_id_role_pk": {
+          "name": "user_role_user_id_role_pk",
+          "columns": [
+            "user_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user_sparcs": {
+      "name": "user_sparcs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_sparcs_user_id_user_id_fk": {
+          "name": "user_sparcs_user_id_user_id_fk",
+          "tableFrom": "user_sparcs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_sparcs_id": {
+          "name": "user_sparcs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "user_sparcs_nickname_unique": {
+          "name": "user_sparcs_nickname_unique",
+          "columns": [
+            "nickname"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_id": {
+          "name": "user_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/src/db/migration/meta/_journal.json
+++ b/src/db/migration/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1742886405193,
       "tag": "0001_luxuriant_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1744259484489,
+      "tag": "0002_smooth_monster_badoon",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/user-role.ts
+++ b/src/db/schema/user-role.ts
@@ -1,0 +1,25 @@
+import {
+  index,
+  int,
+  mysqlTable,
+  primaryKey,
+  varchar,
+} from 'drizzle-orm/mysql-core'
+import { timestamps } from '@/db/fields'
+import { users } from '@/db/schema/user'
+import { roles } from '@/lib/role'
+
+export const userRoles = mysqlTable(
+  'user_role',
+  {
+    userId: int()
+      .notNull()
+      .references(() => users.id),
+    role: varchar({ length: 20, enum: roles }).notNull(),
+    createdAt: timestamps.createdAt,
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.role] }),
+    index('idx_user_role_01').on(table.userId),
+  ],
+)

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,6 +1,7 @@
 import { sign, verify } from 'hono/jwt'
 import { z } from 'zod'
 import { env } from '@/env'
+import { roles } from '@/lib/role'
 
 const JWT_ALGORITHM = 'HS256'
 
@@ -8,6 +9,7 @@ const tokenSchema = z.object({
   authToken: z.object({
     sub: z.number(),
     iat: z.number(),
+    roles: z.array(z.enum(roles)),
   }),
 })
 type Token = z.infer<typeof tokenSchema>

--- a/src/lib/role.ts
+++ b/src/lib/role.ts
@@ -1,0 +1,2 @@
+export const roles = ['SPARCS', 'WHEEL', 'DIRECTOR'] as const
+export type Role = (typeof roles)[number]

--- a/src/modules/auth/authGuard.ts
+++ b/src/modules/auth/authGuard.ts
@@ -4,11 +4,14 @@ import { HTTPException } from 'hono/http-exception'
 import { cookie } from '@/lib/cookie'
 import { getUnixTimeInSeconds } from '@/lib/date'
 import { jwt } from '@/lib/jwt'
+import { type Role, roles } from '@/lib/role'
+
+type AllowedRole = Role | 'AUTHENTICATED'
 
 type TVariables = { userId: number }
 
-export const authGuard = createMiddleware<{ Variables: TVariables }>(
-  async (c, next) => {
+const createAuthGuard = (allowedRoles: AllowedRole[]) =>
+  createMiddleware<{ Variables: TVariables }>(async (c, next) => {
     const res = await cookie.get(c, 'authToken')
 
     if (!res.ok || res.data === undefined)
@@ -17,12 +20,20 @@ export const authGuard = createMiddleware<{ Variables: TVariables }>(
     const token = res.data
     const payload = await jwt.verify('authToken', token)
 
+    if (
+      !allowedRoles.includes('AUTHENTICATED') &&
+      !payload.roles.some((role) => allowedRoles.includes(role))
+    )
+      throw new HTTPException(403, { message: 'Forbidden' })
+
     c.set('userId', payload.sub)
     await next()
-  },
-)
+  })
 
-type AuthTokenPayload = { sub: number }
+export const authGuard = createAuthGuard(['AUTHENTICATED', ...roles])
+export const authSparcsGuard = createAuthGuard(['SPARCS'])
+
+type AuthTokenPayload = { sub: number; roles: Role[] }
 
 export const signAuthToken = (payload: AuthTokenPayload) => {
   const iat = getUnixTimeInSeconds()

--- a/src/modules/auth/authRepo.ts
+++ b/src/modules/auth/authRepo.ts
@@ -29,7 +29,9 @@ export const findUserByAccount = async (
   return res?.user ?? null
 }
 
-export const createAccount = (
+export const createAccount = async (
   account: AccountInsert,
   client: QueryClient = db,
-) => client.insert(authAccounts).values(account)
+) => {
+  await client.insert(authAccounts).values(account)
+}

--- a/src/modules/auth/authRepo.ts
+++ b/src/modules/auth/authRepo.ts
@@ -29,9 +29,7 @@ export const findUserByAccount = async (
   return res?.user ?? null
 }
 
-export const createAccount = async (
+export const createAccount = (
   account: AccountInsert,
   client: QueryClient = db,
-) => {
-  await client.insert(authAccounts).values(account)
-}
+) => client.insert(authAccounts).values(account)

--- a/src/modules/auth/authRoute.ts
+++ b/src/modules/auth/authRoute.ts
@@ -50,8 +50,8 @@ const app = new Hono()
       const { access_token } = await google.issueToken(code)
       const googleInfo = await google.getUserInfo(access_token)
 
-      const { userId, userRoles } =
-        await authService.getOrRegisterUserByGoogle(googleInfo)
+      const userId = await authService.getOrRegisterUserByGoogle(googleInfo)
+      const userRoles = await authService.getUserRoles(userId)
 
       const authToken = await signAuthToken({ sub: userId, roles: userRoles })
       await setAuthToken(c, authToken)

--- a/src/modules/auth/authRoute.ts
+++ b/src/modules/auth/authRoute.ts
@@ -50,9 +50,10 @@ const app = new Hono()
       const { access_token } = await google.issueToken(code)
       const googleInfo = await google.getUserInfo(access_token)
 
-      const userId = await authService.getOrRegisterUserByGoogle(googleInfo)
+      const { userId, userRoles } =
+        await authService.getOrRegisterUserByGoogle(googleInfo)
 
-      const authToken = await signAuthToken({ sub: userId })
+      const authToken = await signAuthToken({ sub: userId, roles: userRoles })
       await setAuthToken(c, authToken)
 
       return c.redirect(redirectURL)

--- a/src/modules/auth/authService.ts
+++ b/src/modules/auth/authService.ts
@@ -1,13 +1,15 @@
 import { transaction } from '@/db'
 import { createAccount, findUserByAccount } from '@/modules/auth/authRepo'
 import { type GoogleUserInfo } from '@/modules/auth/google'
-import { registerUser } from '@/modules/user/userService'
+import { getUserRoles, registerUser } from '@/modules/user/userService'
 
-const findUserByGoogleAccount = (googleAccountId: string) =>
-  findUserByAccount({
+const findUserByGoogleAccount = async (googleAccountId: string) => {
+  const user = await findUserByAccount({
     provider: 'GOOGLE',
     providerAccountId: googleAccountId,
   })
+  return user?.id ?? null
+}
 
 const registerUserAndCreateGoogleAccount = async (googleInfo: GoogleUserInfo) =>
   transaction(async (client) => {
@@ -33,7 +35,9 @@ const registerUserAndCreateGoogleAccount = async (googleInfo: GoogleUserInfo) =>
   })
 
 export const getOrRegisterUserByGoogle = async (googleInfo: GoogleUserInfo) => {
-  const user = await findUserByGoogleAccount(googleInfo.sub)
-  if (user !== null) return user.id
-  return registerUserAndCreateGoogleAccount(googleInfo)
+  const userId =
+    (await findUserByGoogleAccount(googleInfo.sub)) ||
+    (await registerUserAndCreateGoogleAccount(googleInfo))
+  const userRoles = await getUserRoles(userId)
+  return { userId, userRoles }
 }

--- a/src/modules/auth/authService.ts
+++ b/src/modules/auth/authService.ts
@@ -1,15 +1,16 @@
 import { transaction } from '@/db'
-import { createAccount, findUserByAccount } from '@/modules/auth/authRepo'
+import * as authRepo from '@/modules/auth/authRepo'
 import { type GoogleUserInfo } from '@/modules/auth/google'
-import { getUserRoles, registerUser } from '@/modules/user/userService'
+import {
+  getUserRoles as _getUserRoles,
+  registerUser,
+} from '@/modules/user/userService'
 
-const findUserByGoogleAccount = async (googleAccountId: string) => {
-  const user = await findUserByAccount({
+const findUserByGoogleAccount = (googleAccountId: string) =>
+  authRepo.findUserByAccount({
     provider: 'GOOGLE',
     providerAccountId: googleAccountId,
   })
-  return user?.id ?? null
-}
 
 const registerUserAndCreateGoogleAccount = async (googleInfo: GoogleUserInfo) =>
   transaction(async (client) => {
@@ -20,7 +21,7 @@ const registerUserAndCreateGoogleAccount = async (googleInfo: GoogleUserInfo) =>
       },
       client,
     )
-    await createAccount(
+    await authRepo.createAccount(
       {
         name: googleInfo.name,
         userId,
@@ -35,9 +36,9 @@ const registerUserAndCreateGoogleAccount = async (googleInfo: GoogleUserInfo) =>
   })
 
 export const getOrRegisterUserByGoogle = async (googleInfo: GoogleUserInfo) => {
-  const userId =
-    (await findUserByGoogleAccount(googleInfo.sub)) ||
-    (await registerUserAndCreateGoogleAccount(googleInfo))
-  const userRoles = await getUserRoles(userId)
-  return { userId, userRoles }
+  const user = await findUserByGoogleAccount(googleInfo.sub)
+  if (user !== null) return user.id
+  return registerUserAndCreateGoogleAccount(googleInfo)
 }
+
+export const getUserRoles = (userId: number) => _getUserRoles(userId)

--- a/src/modules/user/userRepo.ts
+++ b/src/modules/user/userRepo.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm'
 import { type QueryClient, db } from '@/db'
 import { type UserInsert, users } from '@/db/schema/user'
+import { userRoles } from '@/db/schema/user-role'
 
 export const findUser = async (id: number, client: QueryClient = db) => {
   const [user] = await client.select().from(users).where(eq(users.id, id))
@@ -14,3 +15,11 @@ export const createUser = async (
   const [data] = await client.insert(users).values(user).$returningId()
   return data!.id
 }
+
+export const findUserRoles = (userId: number, client: QueryClient = db) =>
+  client
+    .select({
+      role: userRoles.role,
+    })
+    .from(userRoles)
+    .where(eq(userRoles.userId, userId))

--- a/src/modules/user/userRepo.ts
+++ b/src/modules/user/userRepo.ts
@@ -85,7 +85,7 @@ export const searchSparcsUser = async (
   }
 }
 
-export const findUserRoles = (userId: number, client: QueryClient = db) =>
+export const getUserRoles = (userId: number, client: QueryClient = db) =>
   client
     .select({
       role: userRoles.role,

--- a/src/modules/user/userRoute.ts
+++ b/src/modules/user/userRoute.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { authGuard } from '@/modules/auth/authGuard'
+import { authGuard, authSparcsGuard } from '@/modules/auth/authGuard'
 import * as userService from '@/modules/user/userService'
 
 const app = new Hono()
@@ -14,6 +14,7 @@ const app = new Hono()
   })
   .get(
     '/:id',
+    authSparcsGuard,
     zValidator('param', z.object({ id: z.coerce.number() })),
     async (c) => {
       const { id } = c.req.valid('param')

--- a/src/modules/user/userService.ts
+++ b/src/modules/user/userService.ts
@@ -22,7 +22,7 @@ export const registerUser = (
 export const searchSparcsUser = (keyword: string, page: number, size: number) =>
   userRepo.searchSparcsUser(keyword, page, size)
 
-export const getUserRoles = (userId: number) =>
-  userRepo
-    .findUserRoles(userId)
-    .then((userRoles) => userRoles.map(({ role }) => role))
+export const getUserRoles = async (userId: number) => {
+  const userRoles = await userRepo.getUserRoles(userId)
+  return userRoles.map(({ role }) => role)
+}

--- a/src/modules/user/userService.ts
+++ b/src/modules/user/userService.ts
@@ -18,3 +18,8 @@ export const registerUser = (
   },
   client: QueryClient,
 ) => userRepo.createUser(user, client)
+
+export const getUserRoles = (userId: number) =>
+  userRepo
+    .findUserRoles(userId)
+    .then((userRoles) => userRoles.map(({ role }) => role))


### PR DESCRIPTION
### 내용

- 사용자에게 부여된 역할을 저장하는 `user_role` 테이블을 추가합니다.
- JWT에 저장되는 `roles` 속성을 통해 DB 접근 없이 사용자의 권한을 확인합니다.

### Todo

- 향후 Wheel 또는 임원진만 접근할 수 있는 Endpoint가 추가될 경우, 필요한 authGuard를 생성합니다.
- 사용자에게 역할을 부여하거나 회수할 수 있는 Endpoint를 만듭니다.